### PR TITLE
[VNext] Relations

### DIFF
--- a/MongoDB.Entities.NewApi/Configuration/CollectionRelationConfig.cs
+++ b/MongoDB.Entities.NewApi/Configuration/CollectionRelationConfig.cs
@@ -1,0 +1,16 @@
+﻿namespace MongoDB.Entities.Configuration;
+
+using System;
+
+/// <summary>
+/// Describes a CollectionReference
+/// </summary>
+internal class CollectionRelationConfig<T> : PerRelationConfiguration<T>
+{
+    public CollectionRelationConfig(string fieldName, Type otherType, string otherDatabaseName, string otherCollectionName) : base(fieldName, otherType, otherDatabaseName, otherCollectionName)
+    {
+
+    }
+    //since this is the inverse side of a DocumentRelationConfig, we don't need to
+    //add anything here, we only need to configure the DocumentRelationConfig for each relationship
+}

--- a/MongoDB.Entities.NewApi/Configuration/DocumentRelationConfig.cs
+++ b/MongoDB.Entities.NewApi/Configuration/DocumentRelationConfig.cs
@@ -1,0 +1,20 @@
+﻿namespace MongoDB.Entities.Configuration;
+
+using System;
+using System.Linq.Expressions;
+
+/// <summary>
+/// Describes a DocumentReference
+/// </summary>
+internal class DocumentRelationConfig<T> : PerRelationConfiguration<T>
+{
+    public DocumentRelationConfig(Expression<Func<T, object>> idSelector, string fieldName, Type otherType, string otherDatabaseName, string otherCollectionName) : base(fieldName, otherType, otherDatabaseName, otherCollectionName)
+    {
+        IdSelector = idSelector;
+    }
+
+    /// <summary>
+    /// Selects an Id from the type
+    /// </summary>
+    public Expression<Func<T, object>> IdSelector { get; }
+}

--- a/MongoDB.Entities.NewApi/Configuration/EntityConfigBuilder.cs
+++ b/MongoDB.Entities.NewApi/Configuration/EntityConfigBuilder.cs
@@ -1,0 +1,39 @@
+﻿namespace MongoDB.Entities.Configuration;
+
+using System.Linq.Expressions;
+//TODO: create a proper builder like EF core
+public class EntityConfigBuilder<T>
+{
+    private MongoDbEntityMappingConfiguration _mappingConfiguration;
+
+    public EntityConfigBuilder(MongoDbEntityMappingConfiguration mappingConfiguration)
+    {
+        _mappingConfiguration = mappingConfiguration;
+    }
+
+    public EntityDocumentRelationConfigBuilder<T, TOther> HasOne<TOther>(Expression<Func<T, MongoDBDocumentReference<TOther>>> selector)
+    {
+        return new(selector);
+    }
+}
+
+public class EntityDocumentRelationConfigBuilder<T, TOther>
+{
+    Expression<Func<T, MongoDBDocumentReference<TOther>>> _selector;
+    public EntityDocumentRelationConfigBuilder(Expression<Func<T, MongoDBDocumentReference<TOther>>> selector)
+    {
+        _selector = selector;
+    }
+
+    Expression<Func<T, object>>? _idSelector;
+    public EntityDocumentRelationConfigBuilder<T, TOther> WithId(Expression<Func<T, object>> idSelector)
+    {
+        _idSelector = idSelector;
+        return this;
+    }
+
+    internal void BuildDocumentSide()
+    {
+        
+    }
+}

--- a/MongoDB.Entities.NewApi/Configuration/MongoDBCollectionReference.cs
+++ b/MongoDB.Entities.NewApi/Configuration/MongoDBCollectionReference.cs
@@ -1,0 +1,20 @@
+﻿namespace MongoDB.Entities.Configuration;
+
+using MongoDB.Bson.Serialization.Attributes;
+
+/// <summary>
+/// References a collection of a type
+/// </summary>
+/// <typeparam name="TOtherType"></typeparam>
+public class MongoDBCollectionReference<TOtherType>
+{
+    //There shouldn't be any serializable members here
+    public MongoDBCollectionReference()
+    {
+    }
+
+
+    [BsonIgnore]
+    public List<TOtherType>? Cache { get; internal set; }
+}
+

--- a/MongoDB.Entities.NewApi/Configuration/MongoDBDocumentReference.cs
+++ b/MongoDB.Entities.NewApi/Configuration/MongoDBDocumentReference.cs
@@ -1,0 +1,18 @@
+﻿namespace MongoDB.Entities.Configuration;
+
+using MongoDB.Bson.Serialization.Attributes;
+
+/// <summary>
+/// References a document of a type, but doesn't store the physical reference
+/// </summary>
+/// <typeparam name="TOtherType"></typeparam>
+public class MongoDBDocumentReference<TOtherType>
+{
+    //There shouldn't be any serializable members here
+    public MongoDBDocumentReference()
+    {
+    }
+
+    [BsonIgnore]
+    public TOtherType? Cache { get; internal set; }
+}

--- a/MongoDB.Entities.NewApi/Configuration/MongoDbEntityMappingConfiguration.cs
+++ b/MongoDB.Entities.NewApi/Configuration/MongoDbEntityMappingConfiguration.cs
@@ -1,0 +1,30 @@
+﻿namespace MongoDB.Entities.Configuration;
+
+using System;
+
+/// <summary>
+/// Stores mapping configuration for multiple entities
+/// </summary>
+public class MongoDbEntityMappingConfiguration
+{
+    public MongoDbEntityMappingConfiguration ConfigEntity<T>(Action<EntityConfigBuilder<T>> action)
+    {
+        action(new(this));
+        return this;
+    }
+    internal Dictionary<Type, object> PerTypeConfig { get; } = new();
+
+    internal PerTypeConfiguration<T>? GetConfigOfType<T>(Func<PerTypeConfiguration<T>>? orDefault = null)
+    {
+        var t = typeof(T);
+        if (PerTypeConfig.TryGetValue(t, out var res))
+        {
+            return (PerTypeConfiguration<T>)res;
+        }
+        if (orDefault != null)
+        {
+            PerTypeConfig[t] = orDefault();
+        }
+        return null;
+    }
+}

--- a/MongoDB.Entities.NewApi/Configuration/PerRelationConfiguration.cs
+++ b/MongoDB.Entities.NewApi/Configuration/PerRelationConfiguration.cs
@@ -1,0 +1,32 @@
+﻿namespace MongoDB.Entities.Configuration;
+
+using System;
+
+internal abstract class PerRelationConfiguration<T>
+{
+    protected PerRelationConfiguration(string fieldName, Type otherType, string otherDatabaseName, string otherCollectionName)
+    {
+        FieldName = fieldName;
+        OtherType = otherType;
+        OtherDatabaseName = otherDatabaseName;
+        OtherCollectionName = otherCollectionName;
+    }
+
+    public string FieldName { get; set; }
+    public Type OtherType { get; set; }
+
+    /// <summary>
+    /// Allows for cross-server queries
+    /// </summary>
+    public string? OtherConnectionString { get; set; }
+
+    /// <summary>
+    /// Allows for cross-database queries
+    /// </summary>
+    public string? OtherDatabaseName { get; set; }
+
+    /// <summary>
+    /// The name of the other collection
+    /// </summary>
+    public string OtherCollectionName { get; set; }
+}

--- a/MongoDB.Entities.NewApi/Configuration/PerTypeConfiguration.cs
+++ b/MongoDB.Entities.NewApi/Configuration/PerTypeConfiguration.cs
@@ -1,0 +1,7 @@
+﻿namespace MongoDB.Entities.Configuration;
+
+internal class PerTypeConfiguration<T>
+{
+    public string? DefaultCollectionName { get; set; }
+    public List<PerRelationConfiguration<T>> Relations { get; } = new();
+}

--- a/MongoDB.Entities.NewApi/Example/Course.cs
+++ b/MongoDB.Entities.NewApi/Example/Course.cs
@@ -1,0 +1,25 @@
+﻿namespace MongoDB.Entities.Example;
+
+using MongoDB.Bson;
+using MongoDB.Entities.Configuration;
+using MongoDB.Entities.NewApi;
+
+public class Course : IEntity<ObjectId>
+{
+    public ObjectId Id { get; }
+    public string Name { get; set; }
+
+
+    /// <summary>
+    /// This API shouldn't assume the Id structre of the related entities
+    /// </summary>
+    public ObjectId TeacherId { get; set; }
+    public MongoDBDocumentReference<Teacher> Teacher { get; set; } = new();
+    //Also works:
+    //public DocumentReference<BsonDocument> Teacher { get; set; } = new();
+
+    public ObjectId? SubstituteTeacherId { get; set; }
+    public MongoDBDocumentReference<Teacher> SubstituteTeacher { get; set; } = new();
+
+    public MongoDBCollectionReference<StudentCourse> Participants { get; set; } = new();
+}

--- a/MongoDB.Entities.NewApi/Example/Student.cs
+++ b/MongoDB.Entities.NewApi/Example/Student.cs
@@ -1,0 +1,17 @@
+﻿namespace MongoDB.Entities.Example;
+
+using MongoDB.Bson;
+using MongoDB.Entities.Configuration;
+using MongoDB.Entities.NewApi;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+public class Student : IEntity<ObjectId>
+{
+    public ObjectId Id { get; }
+
+    public string Name { get; set; }
+
+    public MongoDBCollectionReference<StudentCourse> Courses { get; set; } = new();
+}

--- a/MongoDB.Entities.NewApi/Example/StudentCourse.cs
+++ b/MongoDB.Entities.NewApi/Example/StudentCourse.cs
@@ -1,0 +1,15 @@
+﻿namespace MongoDB.Entities.Example;
+
+using MongoDB.Bson;
+using MongoDB.Entities.Configuration;
+
+public class StudentCourse
+{
+    public ObjectId StudentId { get; set; }
+    public MongoDBDocumentReference<Student> Student { get; set; } = new();
+
+    public ObjectId CourseId { get; set; }
+    public MongoDBDocumentReference<Course> Course { get; set; } = new();
+
+    public bool Passed { get; set; }
+}

--- a/MongoDB.Entities.NewApi/Example/Teacher.cs
+++ b/MongoDB.Entities.NewApi/Example/Teacher.cs
@@ -1,0 +1,15 @@
+﻿namespace MongoDB.Entities.Example;
+
+using MongoDB.Bson;
+using MongoDB.Entities.Configuration;
+using MongoDB.Entities.NewApi;
+
+public class Teacher : IEntity<ObjectId>
+{
+    public ObjectId Id { get; }
+
+    public string Name { get; set; }
+
+    public MongoDBCollectionReference<Course> CoursesAsMainTeacher { get; set; } = new();
+    public MongoDBCollectionReference<Course> CoursesAsSubstituteTeacher { get; set; } = new();
+}

--- a/MongoDB.Entities.NewApi/IEntity.cs
+++ b/MongoDB.Entities.NewApi/IEntity.cs
@@ -1,0 +1,10 @@
+﻿namespace MongoDB.Entities.NewApi;
+
+/// <summary>
+/// Marks an entity that can be queried by id
+/// </summary>
+/// <typeparam name="TId"></typeparam>
+public interface IEntity<TId>
+{
+    TId Id { get; }
+}

--- a/MongoDB.Entities.NewApi/MongoDB.Entities.NewApi.csproj
+++ b/MongoDB.Entities.NewApi/MongoDB.Entities.NewApi.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+
+		<Version>21.0.0</Version>
+		<Nullable>enable</Nullable>
+		<PackageReleaseNotes>
+			- New API
+		</PackageReleaseNotes>
+
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<RootNamespace>MongoDB.Entities</RootNamespace>
+		<AssemblyName>MongoDB.Entities</AssemblyName>
+		<Authors>Đĵ ΝιΓΞΗΛψΚ</Authors>
+		<Description>A data access library for MongoDB with an elegant api, LINQ support and built-in entity relationship management.</Description>
+		<PackageProjectUrl>https://mongodb-entities.com</PackageProjectUrl>
+		<Copyright>Đĵ ΝιΓΞΗΛψΚ</Copyright>
+		<PackageId>MongoDB.Entities</PackageId>
+		<Product>MongoDB.Entities</Product>
+		<RepositoryUrl>https://github.com/dj-nitehawk/MongoDB.Entities.git</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageIcon>icon.png</PackageIcon>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageTags>mongodb mongodb-orm mongodb-repo mongodb-repository entities nosql orm linq netcore repository aspnetcore netcore2 netcore3 dotnetstandard database persistance dal repo</PackageTags>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<LangVersion>10.0</LangVersion>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<NoWarn>CS1591,RCS1158</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+		<PackageReference Include="MongoDB.Driver" Version="2.15.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\README.md" Pack="true" PackagePath="\" />
+		<None Include="..\Artwork\icon.png" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+</Project>

--- a/MongoDB.Entities.sln
+++ b/MongoDB.Entities.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28729.10
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32616.157
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MongoDB.Entities", "MongoDB.Entities\MongoDB.Entities.csproj", "{26A6CEA2-CE12-402D-BEF5-7CD18B71A967}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "Tests\Tests.csproj", "{4E9A9925-CB0D-40F6-A06E-0DA90678DD79}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmark", "Benchmark\Benchmark.csproj", "{0ABF1E1B-4B5D-4362-90C2-954B27D5ABCB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoDB.Entities.NewApi", "MongoDB.Entities.NewApi\MongoDB.Entities.NewApi.csproj", "{C3DE87AC-1B26-4110-B33D-AAD4A605BA18}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{0ABF1E1B-4B5D-4362-90C2-954B27D5ABCB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0ABF1E1B-4B5D-4362-90C2-954B27D5ABCB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0ABF1E1B-4B5D-4362-90C2-954B27D5ABCB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3DE87AC-1B26-4110-B33D-AAD4A605BA18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3DE87AC-1B26-4110-B33D-AAD4A605BA18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3DE87AC-1B26-4110-B33D-AAD4A605BA18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3DE87AC-1B26-4110-B33D-AAD4A605BA18}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MongoDB.Entities/ConfigBuilders/DBContextConfigBuilder.cs
+++ b/MongoDB.Entities/ConfigBuilders/DBContextConfigBuilder.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MongoDB.Entities.ConfigBuilders;
+
+/// <summary>
+/// Handles all entity-related config
+/// </summary>
+public class DBContextConfigBuilder
+{
+    public DBContextConfigBuilder(DBContext context)
+    {
+        Context = context;
+    }
+    internal DBContext Context { get; }
+    internal Dictionary<ValueTuple<Type, string>, object> EntityConfigBuilders { get; } = new();
+    public EntityConfigBuilder<T> Entity<T>(string? collectionName = null)
+    {
+        collectionName ??= Context.CollectionName<T>();
+        var key = (typeof(T), collectionName);
+        if (EntityConfigBuilders.TryGetValue(key, out var config))
+        {
+            return (EntityConfigBuilder<T>)config;
+        }
+        var res = new EntityConfigBuilder<T>(this, collectionName);
+        EntityConfigBuilders[key] = res;
+        return res;
+    }
+}

--- a/MongoDB.Entities/ConfigBuilders/DBContextConfigBuilder.cs
+++ b/MongoDB.Entities/ConfigBuilders/DBContextConfigBuilder.cs
@@ -15,6 +15,8 @@ public class DBContextConfigBuilder
     }
     internal DBContext Context { get; }
     internal Dictionary<ValueTuple<Type, string>, object> EntityConfigBuilders { get; } = new();
+    internal readonly HashSet<RelationDecision> _relationDecisions = new();
+
     public EntityConfigBuilder<T> Entity<T>(string? collectionName = null)
     {
         collectionName ??= Context.CollectionName<T>();

--- a/MongoDB.Entities/ConfigBuilders/EntityConfigBuilder.cs
+++ b/MongoDB.Entities/ConfigBuilders/EntityConfigBuilder.cs
@@ -1,0 +1,28 @@
+﻿namespace MongoDB.Entities.ConfigBuilders;
+
+public class EntityConfigBuilder<T>
+{
+    internal DBContextConfigBuilder Parent { get; }
+    internal DBContext Context => Parent.Context;
+    public EntityConfigBuilder(DBContextConfigBuilder parent, string collectionName)
+    {
+        Parent = parent;
+        CollectionName = collectionName;
+    }
+    public string CollectionName { get; }
+
+    internal Expression<Func<T, object>>? _keySelector;
+    internal readonly Dictionary<string, RelationDecision> _relationDecisions = new();
+    public void HasKey(Expression<Func<T, object>> keySelector)
+    {
+        _keySelector = keySelector;
+    }
+    public HasOneEntityConfigBuilder<T, TProp> HasOne<TProp>(Expression<Func<T, IOneRelation<TProp>>> oneSelector)
+    {
+        if (oneSelector.Body is MemberExpression member)
+        {
+            return new HasOneEntityConfigBuilder<T, TProp>(this, member.Member.Name, member, oneSelector);
+        }
+        throw new ArgumentException("Expression must be a member");
+    }
+}

--- a/MongoDB.Entities/ConfigBuilders/EntityConfigBuilder.cs
+++ b/MongoDB.Entities/ConfigBuilders/EntityConfigBuilder.cs
@@ -4,6 +4,7 @@ public class EntityConfigBuilder<T>
 {
     internal DBContextConfigBuilder Parent { get; }
     internal DBContext Context => Parent.Context;
+    internal HashSet<RelationDecision> _relationDecisions => Parent._relationDecisions;
     public EntityConfigBuilder(DBContextConfigBuilder parent, string collectionName)
     {
         Parent = parent;
@@ -12,7 +13,6 @@ public class EntityConfigBuilder<T>
     public string CollectionName { get; }
 
     internal Expression<Func<T, object>>? _keySelector;
-    internal readonly Dictionary<string, RelationDecision> _relationDecisions = new();
     public void HasKey(Expression<Func<T, object>> keySelector)
     {
         _keySelector = keySelector;

--- a/MongoDB.Entities/ConfigBuilders/HasManyEntityConfigBuilder.cs
+++ b/MongoDB.Entities/ConfigBuilders/HasManyEntityConfigBuilder.cs
@@ -2,13 +2,13 @@
 
 namespace MongoDB.Entities.ConfigBuilders;
 
-public class HasOneEntityConfigBuilder<T1, T2>
+public class HasManyEntityConfigBuilder<T1, T2>
 {
     internal string PropName { get; }
     internal EntityConfigBuilder<T1> Parent { get; }
     internal MemberExpression MemberExp { get; }
-    internal Expression<Func<T1, IOneRelation<T2>>> Selector { get; }
-    public HasOneEntityConfigBuilder(EntityConfigBuilder<T1> parent, string propName, MemberExpression memberExp, Expression<Func<T1, IOneRelation<T2>>> selector)
+    internal Expression<Func<T1, IManyRelation<T2>>> Selector { get; }
+    public HasManyEntityConfigBuilder(EntityConfigBuilder<T1> parent, string propName, MemberExpression memberExp, Expression<Func<T1, IManyRelation<T2>>> selector)
     {
         Parent = parent;
         PropName = propName;
@@ -20,25 +20,25 @@ public class HasOneEntityConfigBuilder<T1, T2>
     {
         if (oneInverse.Body is MemberExpression inverseMember)
         {
-            Parent._relationDecisions.Add(new OneOneRelationDecision(typeof(T1), PropName, typeof(T2), inverseMember.Member.Name));
+            Parent._relationDecisions.Add(new OneManyRelationDecision(typeof(T2), inverseMember.Member.Name, typeof(T1), PropName));
         }
         throw new ArgumentException("must be a Member expression", nameof(oneInverse));
     }
     public void WithOne()
     {
-        Parent._relationDecisions.Add(new OneOneRelationDecision(typeof(T1), PropName, typeof(T2), default));
+        Parent._relationDecisions.Add(new OneManyRelationDecision(typeof(T2), default, typeof(T1), PropName));
     }
 
     public void WithMany(Expression<Func<T2, IManyRelation<T1>>> manyInverse)
     {
         if (manyInverse.Body is MemberExpression inverseMember)
         {
-            Parent._relationDecisions.Add(new OneManyRelationDecision(typeof(T1), PropName, typeof(T2), inverseMember.Member.Name));
+            Parent._relationDecisions.Add(new ManyManyRelationDecision(typeof(T1), PropName, typeof(T2), inverseMember.Member.Name));
         }
         throw new ArgumentException("must be a Member expression", nameof(manyInverse));
     }
     public void WithMany()
     {
-        Parent._relationDecisions.Add(new OneManyRelationDecision(typeof(T1), PropName, typeof(T2), default));
+        Parent._relationDecisions.Add(new ManyManyRelationDecision(typeof(T1), PropName, typeof(T2), default));
     }
 }

--- a/MongoDB.Entities/ConfigBuilders/HasOneEntityConfigBuilder.cs
+++ b/MongoDB.Entities/ConfigBuilders/HasOneEntityConfigBuilder.cs
@@ -1,0 +1,44 @@
+﻿using MongoDB.Entities.NewMany;
+
+namespace MongoDB.Entities.ConfigBuilders;
+
+public class HasOneEntityConfigBuilder<T1, T2>
+{
+    internal string PropName { get; }
+    internal EntityConfigBuilder<T1> Parent { get; }
+    internal MemberExpression MemberExp { get; }
+    internal Expression<Func<T1, IOneRelation<T2>>> Selector { get; }
+    public HasOneEntityConfigBuilder(EntityConfigBuilder<T1> parent, string propName, MemberExpression memberExp, Expression<Func<T1, IOneRelation<T2>>> selector)
+    {
+        Parent = parent;
+        PropName = propName;
+        MemberExp = memberExp;
+        Selector = selector;
+    }
+
+    public void WithOne(Expression<Func<T2, IOneRelation<T1>>> oneInverse)
+    {
+        if (oneInverse.Body is MemberExpression inverseMember)
+        {
+            Parent._relationDecisions[PropName] = new OneOneRelationDecision(typeof(T1), PropName, typeof(T2), inverseMember.Member.Name);
+        }
+        throw new ArgumentException("must be a Member expression", nameof(oneInverse));
+    }
+    public void WithOne()
+    {
+        Parent._relationDecisions[PropName] = new OneOneRelationDecision(typeof(T1), PropName, typeof(T2), default);
+    }
+
+    public void WithMany(Expression<Func<T2, IMany<T1>>> manyInverse)
+    {
+        if (manyInverse.Body is MemberExpression inverseMember)
+        { 
+            Parent._relationDecisions[PropName] = new OneManyRelationDecision(typeof(T1), PropName, typeof(T2), inverseMember.Member.Name);
+        }
+        throw new ArgumentException("must be a Member expression", nameof(manyInverse));
+    }
+    public void WithMany()
+    {
+        Parent._relationDecisions[PropName] = new OneManyRelationDecision(typeof(T1), PropName, typeof(T2), default);
+    }
+}

--- a/MongoDB.Entities/ConfigBuilders/RelationDecision.cs
+++ b/MongoDB.Entities/ConfigBuilders/RelationDecision.cs
@@ -1,0 +1,31 @@
+﻿namespace MongoDB.Entities.ConfigBuilders;
+
+
+internal class RelationDecision
+{
+    public RelationDecision(Type firstType, string propInFirst, Type secondType, string? propInSecond)
+    {
+        FirstType = firstType;
+        PropInFirst = propInFirst;
+        SecondType = secondType;
+        PropInSecond = propInSecond;
+    }
+
+    public Type FirstType { get; }
+    public string PropInFirst { get; }
+    public Type SecondType { get; }
+    public string? PropInSecond { get; }
+}
+internal class OneOneRelationDecision : RelationDecision
+{
+    public OneOneRelationDecision(Type firstType, string propInFirst, Type secondType, string? propInSecond) : base(firstType, propInFirst, secondType, propInSecond)
+    {
+    }
+}
+
+internal class OneManyRelationDecision : RelationDecision
+{
+    public OneManyRelationDecision(Type firstType, string propInFirst, Type secondType, string? propInSecond) : base(firstType, propInFirst, secondType, propInSecond)
+    {
+    }
+}

--- a/MongoDB.Entities/ConfigBuilders/RelationDecision.cs
+++ b/MongoDB.Entities/ConfigBuilders/RelationDecision.cs
@@ -1,9 +1,9 @@
 ﻿namespace MongoDB.Entities.ConfigBuilders;
 
 
-internal class RelationDecision
+internal class RelationDecision : IEquatable<RelationDecision?>
 {
-    public RelationDecision(Type firstType, string propInFirst, Type secondType, string? propInSecond)
+    public RelationDecision(Type firstType, string? propInFirst, Type secondType, string? propInSecond)
     {
         FirstType = firstType;
         PropInFirst = propInFirst;
@@ -12,20 +12,59 @@ internal class RelationDecision
     }
 
     public Type FirstType { get; }
-    public string PropInFirst { get; }
+    public string? PropInFirst { get; }
     public Type SecondType { get; }
     public string? PropInSecond { get; }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as RelationDecision);
+    }
+
+    public bool Equals(RelationDecision? other)
+    {
+        return other != null &&
+               EqualityComparer<Type>.Default.Equals(FirstType, other.FirstType) &&
+               PropInFirst == other.PropInFirst &&
+               EqualityComparer<Type>.Default.Equals(SecondType, other.SecondType) &&
+               PropInSecond == other.PropInSecond;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(FirstType, PropInFirst, SecondType, PropInSecond);
+    }
+
+    public static bool operator ==(RelationDecision? left, RelationDecision? right)
+    {
+        return EqualityComparer<RelationDecision?>.Default.Equals(left, right);
+    }
+
+    public static bool operator !=(RelationDecision? left, RelationDecision? right)
+    {
+        return !(left == right);
+    }
 }
 internal class OneOneRelationDecision : RelationDecision
 {
-    public OneOneRelationDecision(Type firstType, string propInFirst, Type secondType, string? propInSecond) : base(firstType, propInFirst, secondType, propInSecond)
+    public OneOneRelationDecision(Type firstType, string? propInFirst, Type secondType, string? propInSecond) : base(firstType, propInFirst, secondType, propInSecond)
     {
     }
 }
 
+/// <summary>
+/// First is One
+/// Second is Many
+/// </summary>
 internal class OneManyRelationDecision : RelationDecision
 {
-    public OneManyRelationDecision(Type firstType, string propInFirst, Type secondType, string? propInSecond) : base(firstType, propInFirst, secondType, propInSecond)
+    public OneManyRelationDecision(Type firstType, string? propInFirst, Type secondType, string? propInSecond) : base(firstType, propInFirst, secondType, propInSecond)
+    {
+    }
+}
+internal class ManyManyRelationDecision : RelationDecision
+{
+    public ManyManyRelationDecision(Type firstType, string? propInFirst, Type secondType, string? propInSecond) : base(firstType, propInFirst, secondType, propInSecond)
     {
     }
 }

--- a/MongoDB.Entities/DBContext/DBContext.Relations.cs
+++ b/MongoDB.Entities/DBContext/DBContext.Relations.cs
@@ -1,0 +1,10 @@
+﻿using MongoDB.Entities.ConfigBuilders;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MongoDB.Entities;
+public partial class DBContext
+{
+   
+}

--- a/MongoDB.Entities/DBContext/DBContext.cs
+++ b/MongoDB.Entities/DBContext/DBContext.cs
@@ -3,6 +3,7 @@ using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver;
+using MongoDB.Entities.ConfigBuilders;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -314,6 +315,20 @@ public partial class DBContext : IMongoDatabase
 
 
     private readonly ConcurrentDictionary<Type, Cache> _cache = new();
+
+    /// <summary>
+    /// TODO: proper place to call this
+    /// </summary>
+    /// <returns></returns>
+    internal DBContextConfigBuilder Configure()
+    {
+        var config = new DBContextConfigBuilder(this);
+        OnConfigure(config);
+        return config;
+    }
+    protected virtual void OnConfigure(DBContextConfigBuilder config)
+    {
+    }
 
     internal EntityCache<T> Cache<T>()
     {

--- a/MongoDB.Entities/DBContext/DBContext.cs
+++ b/MongoDB.Entities/DBContext/DBContext.cs
@@ -328,6 +328,7 @@ public partial class DBContext : IMongoDatabase
     }
     protected virtual void OnConfigure(DBContextConfigBuilder config)
     {
+        
     }
 
     internal EntityCache<T> Cache<T>()
@@ -351,7 +352,7 @@ public partial class DBContext : IMongoDatabase
     }
 
     public async Task<bool> PingNetwork()
-    {
+    {   
         try
         {
             await Database.RunCommandAsync((Command<BsonDocument>)"{ping:1}").ConfigureAwait(false);

--- a/MongoDB.Entities/Extensions/Save.cs
+++ b/MongoDB.Entities/Extensions/Save.cs
@@ -49,9 +49,9 @@ namespace MongoDB.Entities
         /// <param name="session">An optional session if using within a transaction</param>
         /// <param name="cancellation">An optional cancellation token</param>
         /// <param name="tenantPrefix">Optional tenant prefix if using multi-tenancy</param>
-        public static Task<UpdateResult> SaveOnlyAsync<T>(this T entity, Expression<Func<T, object>> members, IClientSessionHandle session = null, CancellationToken cancellation = default, string tenantPrefix = null) where T : IEntity
+        public static Task<UpdateResult> SaveOnlyAsync<T>(this T entity, Expression<Func<T, object>> members, CancellationToken cancellation = default, string? collectionName = null) where T : IEntity
         {
-            return DB.SaveOnlyAsync(entity, members, session, cancellation, tenantPrefix);
+            return DB.Context.SaveOnlyAsync<T, string>(entity, members, cancellation);
         }
 
         /// <summary>

--- a/MongoDB.Entities/Relationships/NewMany.cs
+++ b/MongoDB.Entities/Relationships/NewMany.cs
@@ -74,14 +74,14 @@ Many(Parent)-Many(Child) (B-C)
 //    public override Guid GenerateNewID() => Guid.NewGuid();
 //}
 
-public interface IMany<TChild>
+public interface IManyRelation<TChild>
 {
     Find<TChild, TChild> GetChildrenFind(DBContext context, string? childCollectionName = null, IMongoCollection<TChild>? collection = null);
     Find<TChild, TProjection> GetChildrenFind<TProjection>(DBContext context, string? childCollectionName = null, IMongoCollection<TChild>? collection = null);
     IMongoQueryable<TChild> GetChildrenQuery(DBContext context, string? childCollectionName = null, IMongoCollection<TChild>? collection = null);
 }
 
-public interface IMany<TParent, TChild> : IMany<TChild>
+public interface IMany<TParent, TChild> : IManyRelation<TChild>
 {
     TParent Parent { get; }
 
@@ -93,7 +93,7 @@ public interface IManyToMany<TParent, TChild> : IMany<TParent, TChild>
     bool IsParentOwner { get; }
 }
 public interface IManyToOne<TParent, TChild> : IMany<TParent, TChild>
-{ 
+{
 }
 
 
@@ -102,7 +102,7 @@ public interface IManyToOne<TParent, TChild> : IMany<TParent, TChild>
 /// </summary>
 /// <typeparam name="TChild"></typeparam>
 /// <typeparam name="TChildId"></typeparam>
-public abstract class Many<TChild> : IMany<TChild>
+public abstract class Many<TChild> : IManyRelation<TChild>
 {
     protected Many(PropertyInfo parentProperty, PropertyInfo childProperty)
     {

--- a/MongoDB.Entities/Relationships/NewMany.cs
+++ b/MongoDB.Entities/Relationships/NewMany.cs
@@ -93,7 +93,7 @@ public interface IManyToMany<TParent, TChild> : IMany<TParent, TChild>
     bool IsParentOwner { get; }
 }
 public interface IManyToOne<TParent, TChild> : IMany<TParent, TChild>
-{
+{ 
 }
 
 


### PR DESCRIPTION
Handle all possible relations

Note: One-Many means the `First` entity is `One`, and the `Second` entity is `Many`

### One-One (One Order - One Address)
  - `One<T2>` property in the First entity
  - `One<T1>` property in the Second entity
### One-Many (One Order - Many Items)
  - `Many<T2>` property in the First entity
  - `One<T1>` property in the Second entity
### Many-Many (Many Students - Many Subjects)
  - `Many<T2>` property in the First entity
  - `Many<T1>` property in the Second entity

# Database mapping strategy
## Storage

- One-One will store a field in the second entity that refers to the first entity (more on references later)
- One-Many will be stored as a field in the second entity that refers to the first entity (more on references later)
- Many-Many will be stored as a new collection with each record referring to both entities (more on references later)

## The reference problem
- Up until now, MongoDB.Entities assumed that an entity will ALWAYS have a string ID, since that is changing in the new API, we will have to handle references differently
- No constraints should be enforced on references, means that `One<T>`/`Many<T>` shouldn't force `T` to implement `IEntity<TId>`
- IF `T` implements `IEntity<TId>`, a simplified API can be offered that assumes reference is by `Id`
- That means we will have to introduce a way to configure how references are handled, and `DBContext` is the most suitable place for that


## Query
