### PR TITLE
Add SaveOnlyAsync and SaveExceptAsync methods that accept an IEnumera…

### DIFF
--- a/MongoDB.Entities/Core/Logic.cs
+++ b/MongoDB.Entities/Core/Logic.cs
@@ -19,11 +19,20 @@ internal static class Logic
         return props.Select(p => Builders<T>.Update.Set(p.Name, p.GetValue(entity)));
     }
 
-    internal static IEnumerable<UpdateDefinition<T>> BuildUpdateDefs<T>(T entity, Expression<Func<T, object>> members, bool excludeMode = false) where T : IEntity
+    internal static IEnumerable<string> GetPropNamesFromExpression<T>(Expression<Func<T, object>> expression)
     {
-        var propNames = (members?.Body as NewExpression)?.Arguments
+        return  (expression?.Body as NewExpression)?.Arguments
             .Select(a => a.ToString().Split('.')[1]);
+    }
 
+    internal static IEnumerable<UpdateDefinition<T>> BuildUpdateDefs<T>(T entity, Expression<Func<T, object>> members,
+        bool excludeMode = false) where T : IEntity
+    {
+        return BuildUpdateDefs(entity, GetPropNamesFromExpression(members), excludeMode);
+    }
+    
+    internal static IEnumerable<UpdateDefinition<T>> BuildUpdateDefs<T>(T entity, IEnumerable<string> propNames, bool excludeMode = false) where T : IEntity
+    {
         if (!propNames.Any())
             throw new ArgumentException("Unable to get any properties from the members expression!");
 

--- a/MongoDB.Entities/DBContext/DBContext.Save.cs
+++ b/MongoDB.Entities/DBContext/DBContext.Save.cs
@@ -57,6 +57,23 @@ public partial class DBContext
     }
 
     /// <summary>
+    /// Saves an entity partially with only the specified subset of properties. 
+    /// If ID value is null, a new entity is created. If ID has a value, then existing entity is updated.
+    /// <para>TIP: The properties to be saved can be specified with an IEnumerable. 
+    /// Property names must match exactly.</para>
+    /// </summary>
+    /// <typeparam name="T">Any class that implements IEntity</typeparam>
+    /// <param name="entity">The entity to save</param>
+    /// <param name="propNames">new List { "PropOne", "PropTwo" }</param>
+    /// <param name="cancellation">An optional cancellation token</param>
+    public Task<UpdateResult> SaveOnlyAsync<T>(T entity, IEnumerable<string> propNames, CancellationToken cancellation = default) where T : IEntity
+    {
+        SetModifiedBySingle(entity);
+        OnBeforeSave<T>()?.Invoke(entity);
+        return DB.SaveOnlyAsync(entity, propNames, Session, cancellation);
+    }
+
+    /// <summary>
     /// Saves a batch of entities partially with only the specified subset of properties. 
     /// If ID value is null, a new entity is created. If ID has a value, then existing entity is updated.
     /// <para>TIP: The properties to be saved can be specified with a 'New' expression. 
@@ -71,6 +88,23 @@ public partial class DBContext
         SetModifiedByMultiple(entities);
         foreach (var ent in entities) OnBeforeSave<T>()?.Invoke(ent);
         return DB.SaveOnlyAsync(entities, members, Session, cancellation);
+    }
+
+    /// <summary>
+    /// Saves a batch of entities partially with only the specified subset of properties. 
+    /// If ID value is null, a new entity is created. If ID has a value, then existing entity is updated.
+    /// <para>TIP: The properties to be saved can be specified with an IEnumerable. 
+    /// Property names must match exactly.</para>
+    /// </summary>
+    /// <typeparam name="T">Any class that implements IEntity</typeparam>
+    /// <param name="entities">The batch of entities to save</param>
+    /// <param name="propNames">new List { "PropOne", "PropTwo" }</param>
+    /// <param name="cancellation">An optional cancellation token</param>
+    public Task<BulkWriteResult<T>> SaveOnlyAsync<T>(IEnumerable<T> entities, IEnumerable<string> propNames, CancellationToken cancellation = default) where T : IEntity
+    {
+        SetModifiedByMultiple(entities);
+        foreach (var ent in entities) OnBeforeSave<T>()?.Invoke(ent);
+        return DB.SaveOnlyAsync(entities, propNames, Session, cancellation);
     }
 
     /// <summary>
@@ -91,6 +125,23 @@ public partial class DBContext
     }
 
     /// <summary>
+    /// Saves an entity partially excluding the specified subset of properties. 
+    /// If ID value is null, a new entity is created. If ID has a value, then existing entity is updated.
+    /// <para>TIP: The properties to be saved can be specified with an IEnumerable. 
+    /// Property names must match exactly.</para>
+    /// </summary>
+    /// <typeparam name="T">Any class that implements IEntity</typeparam>
+    /// <param name="entity">The entity to save</param>
+    /// <param name="propNames">new List { "PropOne", "PropTwo" }</param>
+    /// <param name="cancellation">An optional cancellation token</param>
+    public Task<UpdateResult> SaveExceptAsync<T>(T entity, IEnumerable<string> propNames, CancellationToken cancellation = default) where T : IEntity
+    {
+        SetModifiedBySingle(entity);
+        OnBeforeSave<T>()?.Invoke(entity);
+        return DB.SaveExceptAsync(entity, propNames, Session, cancellation);
+    }
+
+    /// <summary>
     /// Saves a batch of entities partially excluding the specified subset of properties. 
     /// If ID value is null, a new entity is created. If ID has a value, then existing entity is updated.
     /// <para>TIP: The properties to be excluded can be specified with a 'New' expression. 
@@ -105,6 +156,23 @@ public partial class DBContext
         SetModifiedByMultiple(entities);
         foreach (var ent in entities) OnBeforeSave<T>()?.Invoke(ent);
         return DB.SaveExceptAsync(entities, members, Session, cancellation);
+    }
+
+    /// <summary>
+    /// Saves a batch of entities partially excluding the specified subset of properties. 
+    /// If ID value is null, a new entity is created. If ID has a value, then existing entity is updated.
+    /// <para>TIP: The properties to be saved can be specified with an IEnumerable. 
+    /// Property names must match exactly.</para>
+    /// </summary>
+    /// <typeparam name="T">Any class that implements IEntity</typeparam>
+    /// <param name="entities">The batch of entities to save</param>
+    /// <param name="propNames">new List { "PropOne", "PropTwo" }</param>
+    /// <param name="cancellation">An optional cancellation token</param>
+    public Task<BulkWriteResult<T>> SaveExceptAsync<T>(IEnumerable<T> entities, IEnumerable<string> propNames, CancellationToken cancellation = default) where T : IEntity
+    {
+        SetModifiedByMultiple(entities);
+        foreach (var ent in entities) OnBeforeSave<T>()?.Invoke(ent);
+        return DB.SaveExceptAsync(entities, propNames, Session, cancellation);
     }
 
     /// <summary>

--- a/MongoDB.Entities/Extensions/Save.cs
+++ b/MongoDB.Entities/Extensions/Save.cs
@@ -50,6 +50,22 @@ public static partial class Extensions
     }
 
     /// <summary>
+    /// Saves an entity partially with only the specified subset of properties. 
+    /// If ID value is null, a new entity is created. If ID has a value, then existing entity is updated.
+    /// <para>TIP: The properties to be saved can be specified with an IEnumerable. 
+    /// Property names must match exactly.</para>
+    /// </summary>
+    /// <typeparam name="T">Any class that implements IEntity</typeparam>
+    /// <param name="entity">The entity to save</param>
+    /// <param name="propNames">new List { "PropOne", "PropTwo" }</param>
+    /// <param name="session">An optional session if using within a transaction</param>
+    /// <param name="cancellation">An optional cancellation token</param>
+    public static Task<UpdateResult> SaveOnlyAsync<T>(this T entity, IEnumerable<string> propNames, IClientSessionHandle session = null, CancellationToken cancellation = default) where T : IEntity
+    {
+        return DB.SaveOnlyAsync(entity, propNames, session, cancellation);
+    }
+
+    /// <summary>
     /// Saves a batch of entities partially with only the specified subset of properties. 
     /// If ID value is null, a new entity is created. If ID has a value, then existing entity is updated.
     /// <para>TIP: The properties to be saved can be specified with a 'New' expression. 
@@ -63,6 +79,22 @@ public static partial class Extensions
     public static Task<BulkWriteResult<T>> SaveOnlyAsync<T>(this IEnumerable<T> entities, Expression<Func<T, object>> members, IClientSessionHandle session = null, CancellationToken cancellation = default) where T : IEntity
     {
         return DB.SaveOnlyAsync(entities, members, session, cancellation);
+    }
+
+    /// <summary>
+    /// Saves a batch of entities partially with only the specified subset of properties. 
+    /// If ID value is null, a new entity is created. If ID has a value, then existing entity is updated.
+    /// <para>TIP: The properties to be saved can be specified with an IEnumerable. 
+    /// Property names must match exactly.</para>
+    /// </summary>
+    /// <typeparam name="T">Any class that implements IEntity</typeparam>
+    /// <param name="entities">The batch of entities to save</param>
+    /// <param name="propNames">new List { "PropOne", "PropTwo" }</param>
+    /// <param name="session">An optional session if using within a transaction</param>
+    /// <param name="cancellation">An optional cancellation token</param>
+    public static Task<BulkWriteResult<T>> SaveOnlyAsync<T>(this IEnumerable<T> entities, IEnumerable<string> propNames, IClientSessionHandle session = null, CancellationToken cancellation = default) where T : IEntity
+    {
+        return DB.SaveOnlyAsync(entities, propNames, session, cancellation);
     }
 
     /// <summary>
@@ -82,6 +114,22 @@ public static partial class Extensions
     }
 
     /// <summary>
+    /// Saves an entity partially excluding the specified subset of properties. 
+    /// If ID value is null, a new entity is created. If ID has a value, then existing entity is updated.
+    /// <para>TIP: The properties to be saved can be specified with an IEnumerable. 
+    /// Property names must match exactly.</para>
+    /// </summary>
+    /// <typeparam name="T">Any class that implements IEntity</typeparam>
+    /// <param name="entity">The entity to save</param>
+    /// <param name="propNames">new List { "PropOne", "PropTwo" }</param>
+    /// <param name="session">An optional session if using within a transaction</param>
+    /// <param name="cancellation">An optional cancellation token</param>
+    public static Task<UpdateResult> SaveExceptAsync<T>(this T entity, IEnumerable<string> propNames, IClientSessionHandle session = null, CancellationToken cancellation = default) where T : IEntity
+    {
+        return DB.SaveExceptAsync(entity, propNames, session, cancellation);
+    }
+
+    /// <summary>
     /// Saves a batch of entities partially excluding the specified subset of properties. 
     /// If ID value is null, a new entity is created. If ID has a value, then existing entity is updated.
     /// <para>TIP: The properties to be excluded can be specified with a 'New' expression. 
@@ -95,6 +143,22 @@ public static partial class Extensions
     public static Task<BulkWriteResult<T>> SaveExceptAsync<T>(this IEnumerable<T> entities, Expression<Func<T, object>> members, IClientSessionHandle session = null, CancellationToken cancellation = default) where T : IEntity
     {
         return DB.SaveExceptAsync(entities, members, session, cancellation);
+    }
+
+    /// <summary>
+    /// Saves a batch of entities partially excluding the specified subset of properties. 
+    /// If ID value is null, a new entity is created. If ID has a value, then existing entity is updated.
+    /// <para>TIP: The properties to be saved can be specified with an IEnumerable. 
+    /// Property names must match exactly.</para>
+    /// </summary>
+    /// <typeparam name="T">Any class that implements IEntity</typeparam>
+    /// <param name="entities">The batch of entities to save</param>
+    /// <param name="propNames">new List { "PropOne", "PropTwo" }</param>
+    /// <param name="session">An optional session if using within a transaction</param>
+    /// <param name="cancellation">An optional cancellation token</param>
+    public static Task<BulkWriteResult<T>> SaveExceptAsync<T>(this IEnumerable<T> entities, IEnumerable<string> propNames, IClientSessionHandle session = null, CancellationToken cancellation = default) where T : IEntity
+    {
+        return DB.SaveExceptAsync(entities, propNames, session, cancellation);
     }
 
     /// <summary>


### PR DESCRIPTION
In working with GraphQL, we never know the properties that will be used in a partial update. We have a list of properties that are being updated. Having save partials that accept an IEnumerable<string> is more efficient than creating he Expression for SavePartialAsync and have it just create an IEnumerable<string>