### PR TITLE
Fix dictionary indexes

### DIFF
--- a/MongoDB.Entities/Builders/Index.cs
+++ b/MongoDB.Entities/Builders/Index.cs
@@ -159,6 +159,17 @@ internal class Key<T> where T : IEntity
             return;
         }
 
+        if (expression.Body is MethodCallExpression methodCallExpression
+            && methodCallExpression.Method.DeclaringType.GetGenericTypeDefinition() == typeof(Dictionary<,>)
+            && methodCallExpression.Arguments.Count == 1
+            && methodCallExpression.Arguments[0].Type == typeof(string)
+            && methodCallExpression.Arguments[0] is ConstantExpression constantExpression
+            && methodCallExpression.Object is MemberExpression memberExpression)
+        {
+            PropertyName = $"{memberExpression.Member.Name}.{constantExpression.Value}";
+            return;
+        }
+
         PropertyName = expression.FullPath();
     }
 }

--- a/Tests/TestIndexes.cs
+++ b/Tests/TestIndexes.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MongoDB.Driver;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -185,5 +186,24 @@ public class Indexes
         await DB.Index<Author>()
             .Key(x => x.Age, KeyType.Descending)
             .CreateAsync();
+    }
+
+    [TestMethod]
+    public async Task dictionary_item_index_should_use_key_value()
+    {
+        await DB.DropCollectionAsync<TestModel>();
+
+        var index = await DB.Index<TestModel>()
+          .Key(a => a.Metadata["AnotherKey"], KeyType.Ascending)
+          .Key(a => a.EndDate, KeyType.Ascending)
+          .CreateAsync();
+
+        Assert.AreEqual("Metadata.AnotherKey(Asc) | EndDate(Asc)", index);
+    }
+
+    public class TestModel : Entity
+    {
+        public DateTime EndDate { get; set; }
+        public Dictionary<string, object> Metadata { get; set; } = new();
     }
 }


### PR DESCRIPTION
Hi,

I was trying to create indexes using dictionary keys, but it wasn't working because the key was being created using the `get_Item` method name instead of its argument expression value.

I created a test and a fix for it. But feel free to modify the code as you are more familiar with the codebase.

Index **before** the change:
`Metadata.get_Item(Asc) | EndDate(Asc)`

Index **after** the change:
`Metadata.AnotherKey(Asc) | EndDate(Asc)`