### PR TITLE
Update DB.Watcher.cs for thread safety

### DIFF
--- a/MongoDB.Entities/DB/DB.Watcher.cs
+++ b/MongoDB.Entities/DB/DB.Watcher.cs
@@ -13,12 +13,11 @@ public static partial class DB
     /// <param name="name">A unique name for the watcher of this entity type. Names can be duplicate among different entity types.</param>
     public static Watcher<T> Watcher<T>(string name) where T : IEntity
     {
-        if (Cache<T>.Watchers.TryGetValue(name.ToLower().Trim(), out var watcher))
-            return watcher;
+        // Normalize the name once
+        var normalizedName = name.ToLower().Trim();
 
-        watcher = new(name.ToLower().Trim());
-        Cache<T>.Watchers.TryAdd(name, watcher);
-        return watcher;
+        // Use GetOrAdd to ensure thread-safe retrieval or addition of the watcher.
+        return Cache<T>.Watchers.GetOrAdd(normalizedName, newName => new Watcher<T>(newName));
     }
 
     /// <summary>


### PR DESCRIPTION
the way the TryGetValue and TryAdd methods are used here opens up a potential race condition where two threads could end up creating two instances of Watcher<T> for the same name before adding it to the cache.

To improve thread safety and ensure only a single instance of Watcher<T> is created and returned for each name, you can use the GetOrAdd method provided by ConcurrentDictionary. This method atomically searches for a value for a given key; if it doesn't find it, it creates the value using the factory method provided and adds it to the dictionary, ensuring that only one instance is created even in the presence of multiple concurrent writers.