### PR TITLE
add in testcontainers so that contributors do not need to run a replica set locally

### DIFF
--- a/Tests/EntityIdTests/TestMultiDb.cs
+++ b/Tests/EntityIdTests/TestMultiDb.cs
@@ -15,8 +15,7 @@ public class MultiDbEntity
     [TestMethod]
     public async Task save_entity_works()
     {
-        await DB.InitAsync(dbName, InitTest.ClientSettings);
-
+        await InitTest.InitTestDatabase(dbName);
         DB.DatabaseFor<BookCover>(dbName);
         DB.DatabaseFor<BookMark>(dbName);
 
@@ -38,7 +37,7 @@ public class MultiDbEntity
     [TestMethod]
     public async Task relationships_work()
     {
-        await DB.InitAsync(dbName, InitTest.ClientSettings);
+        await InitTest.InitTestDatabase(dbName);
         DB.DatabaseFor<BookCover>(dbName);
         DB.DatabaseFor<BookMark>(dbName);
 
@@ -97,7 +96,7 @@ public class MultiDbEntity
     [TestMethod]
     public async Task dropping_collections()
     {
-        await DB.InitAsync(dbName, InitTest.ClientSettings);
+        await InitTest.InitTestDatabase(dbName);
         DB.DatabaseFor<BookMark>(dbName);
         DB.DatabaseFor<BookCover>(dbName);
 

--- a/Tests/EntityIdTests/TestMultiDb.cs
+++ b/Tests/EntityIdTests/TestMultiDb.cs
@@ -15,7 +15,7 @@ public class MultiDbEntity
     [TestMethod]
     public async Task save_entity_works()
     {
-        await DB.InitAsync(dbName);
+        await DB.InitAsync(dbName, InitTest.ClientSettings);
 
         DB.DatabaseFor<BookCover>(dbName);
         DB.DatabaseFor<BookMark>(dbName);
@@ -38,7 +38,7 @@ public class MultiDbEntity
     [TestMethod]
     public async Task relationships_work()
     {
-        await DB.InitAsync(dbName);
+        await DB.InitAsync(dbName, InitTest.ClientSettings);
         DB.DatabaseFor<BookCover>(dbName);
         DB.DatabaseFor<BookMark>(dbName);
 
@@ -97,7 +97,7 @@ public class MultiDbEntity
     [TestMethod]
     public async Task dropping_collections()
     {
-        await DB.InitAsync(dbName);
+        await DB.InitAsync(dbName, InitTest.ClientSettings);
         DB.DatabaseFor<BookMark>(dbName);
         DB.DatabaseFor<BookCover>(dbName);
 

--- a/Tests/Init.cs
+++ b/Tests/Init.cs
@@ -7,13 +7,32 @@ namespace MongoDB.Entities.Tests;
 [TestClass]
 public static class InitTest
 {
-    public static MongoClientSettings ClientSettings { get; set; }
+    private static MongoClientSettings ClientSettings { get; set; }
+    static bool UseTestContainers;
     
     [AssemblyInitialize]
     public static async Task Init(TestContext _)
     {
-        var testContainer = await TestDatabase.CreateDatabase();
-        ClientSettings = MongoClientSettings.FromConnectionString(testContainer.GetConnectionString());
-        await DB.InitAsync("mongodb-entities-test", ClientSettings);
+        UseTestContainers = System.Environment.GetEnvironmentVariable("MONGODB_ENTITIES_TESTCONTAINERS") != null;
+
+        if (UseTestContainers)
+        {
+            var testContainer = await TestDatabase.CreateDatabase();
+            ClientSettings = MongoClientSettings.FromConnectionString(testContainer.GetConnectionString());
+        }
+
+        await InitTestDatabase("mongodb-entities-test");
+    }
+
+    public static async Task InitTestDatabase(string databaseName)
+    {
+        if (UseTestContainers)
+        {
+            await DB.InitAsync(databaseName, ClientSettings);
+        }
+        else
+        {
+            await DB.InitAsync(databaseName);
+        }
     }
 }

--- a/Tests/Init.cs
+++ b/Tests/Init.cs
@@ -1,14 +1,19 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
+using MongoDB.Driver;
 
 namespace MongoDB.Entities.Tests;
 
 [TestClass]
 public static class InitTest
 {
+    public static MongoClientSettings ClientSettings { get; set; }
+    
     [AssemblyInitialize]
     public static async Task Init(TestContext _)
     {
-        await DB.InitAsync("mongodb-entities-test");
+        var testContainer = await TestDatabase.CreateDatabase();
+        ClientSettings = MongoClientSettings.FromConnectionString(testContainer.GetConnectionString());
+        await DB.InitAsync("mongodb-entities-test", ClientSettings);
     }
 }

--- a/Tests/TestDatabase.cs
+++ b/Tests/TestDatabase.cs
@@ -1,0 +1,42 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Testcontainers.MongoDb;
+
+public static class TestDatabase
+{
+    private static SemaphoreSlim _semaphore = new(1, 1);
+    private static MongoDbContainer? _testContainer;
+
+    public static async Task<MongoDbContainer> CreateDatabase()
+    {
+        await _semaphore.WaitAsync();
+        try
+        {
+            var database = await CreateTestDatabase();
+
+            return database;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    private static async Task<MongoDbContainer> CreateTestDatabase()
+    {
+        if (_testContainer != null)
+        {
+            return _testContainer;
+        }
+        _testContainer = new MongoDbBuilder()
+                         .WithPortBinding(27017)
+                         .WithPassword("username")
+                         .WithUsername("password")
+                         .WithReplicaSet()
+                         .Build();
+
+        await _testContainer.StartAsync();
+        
+        return _testContainer;
+    }
+}

--- a/Tests/TestFileEntity.cs
+++ b/Tests/TestFileEntity.cs
@@ -41,7 +41,7 @@ public class FileEntities
     [TestMethod]
     public async Task uploading_data_from_file_stream()
     {
-        await DB.InitAsync(dbName, InitTest.ClientSettings);
+        await InitTest.InitTestDatabase(dbName);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 800, Width = 600, Name = "Test.Png" };
@@ -61,7 +61,7 @@ public class FileEntities
     [TestMethod]
     public async Task uploading_with_wrong_hash()
     {
-        await DB.InitAsync(dbName, InitTest.ClientSettings);
+        await InitTest.InitTestDatabase(dbName);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 800, Width = 600, Name = "Test-bad-hash.png", MD5 = "wrong-hash" };
@@ -76,7 +76,7 @@ public class FileEntities
     [TestMethod]
     public async Task uploading_with_correct_hash()
     {
-        await DB.InitAsync(dbName, InitTest.ClientSettings);
+        await InitTest.InitTestDatabase(dbName);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 800, Width = 600, Name = "Test-correct-hash.png", MD5 = "cccfa116f0acf41a217cbefbe34cd599" };
@@ -96,7 +96,7 @@ public class FileEntities
     [TestMethod]
     public async Task file_smaller_than_chunk_size()
     {
-        await DB.InitAsync(dbName, InitTest.ClientSettings);
+        await InitTest.InitTestDatabase(dbName);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 100, Width = 100, Name = "Test-small.Png" };
@@ -116,7 +116,7 @@ public class FileEntities
     [TestMethod]
     public async Task deleting_entity_deletes_all_chunks()
     {
-        await DB.InitAsync(dbName, InitTest.ClientSettings);
+        await InitTest.InitTestDatabase(dbName);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { ID = Guid.NewGuid().ToString(), Height = 400, Width = 400, Name = "Test-Delete.Png" };
@@ -148,7 +148,7 @@ public class FileEntities
     [TestMethod]
     public async Task deleting_only_chunks()
     {
-        await DB.InitAsync(dbName, InitTest.ClientSettings);
+        await InitTest.InitTestDatabase(dbName);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 400, Width = 400, Name = "Test-Delete.Png" };
@@ -179,7 +179,7 @@ public class FileEntities
     [TestMethod]
     public async Task downloading_file_chunks_works()
     {
-        await DB.InitAsync(dbName, InitTest.ClientSettings);
+        await InitTest.InitTestDatabase(dbName);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 500, Width = 500, Name = "Test-Download.Png" };
@@ -205,7 +205,7 @@ public class FileEntities
     [TestMethod]
     public async Task downloading_file_chunks_directly()
     {
-        await DB.InitAsync(dbName, InitTest.ClientSettings);
+        await InitTest.InitTestDatabase(dbName);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 500, Width = 500, Name = "Test-Download.Png" };
@@ -231,7 +231,7 @@ public class FileEntities
     [TestMethod]
     public void trying_to_download_when_no_chunks_present()
     {
-        DB.InitAsync(dbName, InitTest.ClientSettings).GetAwaiter().GetResult();
+        InitTest.InitTestDatabase(dbName).GetAwaiter().GetResult();
 
         Assert.ThrowsException<InvalidOperationException>(
             () =>

--- a/Tests/TestFileEntity.cs
+++ b/Tests/TestFileEntity.cs
@@ -41,7 +41,7 @@ public class FileEntities
     [TestMethod]
     public async Task uploading_data_from_file_stream()
     {
-        await DB.InitAsync(dbName);
+        await DB.InitAsync(dbName, InitTest.ClientSettings);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 800, Width = 600, Name = "Test.Png" };
@@ -61,7 +61,7 @@ public class FileEntities
     [TestMethod]
     public async Task uploading_with_wrong_hash()
     {
-        await DB.InitAsync(dbName);
+        await DB.InitAsync(dbName, InitTest.ClientSettings);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 800, Width = 600, Name = "Test-bad-hash.png", MD5 = "wrong-hash" };
@@ -76,7 +76,7 @@ public class FileEntities
     [TestMethod]
     public async Task uploading_with_correct_hash()
     {
-        await DB.InitAsync(dbName);
+        await DB.InitAsync(dbName, InitTest.ClientSettings);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 800, Width = 600, Name = "Test-correct-hash.png", MD5 = "cccfa116f0acf41a217cbefbe34cd599" };
@@ -96,7 +96,7 @@ public class FileEntities
     [TestMethod]
     public async Task file_smaller_than_chunk_size()
     {
-        await DB.InitAsync(dbName);
+        await DB.InitAsync(dbName, InitTest.ClientSettings);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 100, Width = 100, Name = "Test-small.Png" };
@@ -116,7 +116,7 @@ public class FileEntities
     [TestMethod]
     public async Task deleting_entity_deletes_all_chunks()
     {
-        await DB.InitAsync(dbName);
+        await DB.InitAsync(dbName, InitTest.ClientSettings);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { ID = Guid.NewGuid().ToString(), Height = 400, Width = 400, Name = "Test-Delete.Png" };
@@ -148,7 +148,7 @@ public class FileEntities
     [TestMethod]
     public async Task deleting_only_chunks()
     {
-        await DB.InitAsync(dbName);
+        await DB.InitAsync(dbName, InitTest.ClientSettings);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 400, Width = 400, Name = "Test-Delete.Png" };
@@ -179,7 +179,7 @@ public class FileEntities
     [TestMethod]
     public async Task downloading_file_chunks_works()
     {
-        await DB.InitAsync(dbName);
+        await DB.InitAsync(dbName, InitTest.ClientSettings);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 500, Width = 500, Name = "Test-Download.Png" };
@@ -205,7 +205,7 @@ public class FileEntities
     [TestMethod]
     public async Task downloading_file_chunks_directly()
     {
-        await DB.InitAsync(dbName);
+        await DB.InitAsync(dbName, InitTest.ClientSettings);
         DB.DatabaseFor<Image>(dbName);
 
         var img = new Image { Height = 500, Width = 500, Name = "Test-Download.Png" };
@@ -231,7 +231,7 @@ public class FileEntities
     [TestMethod]
     public void trying_to_download_when_no_chunks_present()
     {
-        DB.InitAsync(dbName).GetAwaiter().GetResult();
+        DB.InitAsync(dbName, InitTest.ClientSettings).GetAwaiter().GetResult();
 
         Assert.ThrowsException<InvalidOperationException>(
             () =>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.5.2"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.5.2"/>
+        <PackageReference Include="Testcontainers.MongoDb" Version="3.10.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This makes life easier for contributors. No need to have a local database with replica sets turned on. Also, I use MongoAtlas and do not usually keep a local mongodb.