### PR TITLE
Added DI support for the migration classes

### DIFF
--- a/MongoDB.Entities/DB/DB.Migrate.cs
+++ b/MongoDB.Entities/DB/DB.Migrate.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -71,7 +72,15 @@ public static partial class DB
 
         return !types.Any()
                    ? throw new InvalidOperationException("Didn't find any classes that implement IMigrate interface.")
-                   : Execute(types.Select(t => (IMigration)Activator.CreateInstance(t)));
+                   : Execute(types.Select(t =>
+                   {
+                       if (ServiceProvider != null)
+                       {
+                           return (IMigration)ActivatorUtilities.CreateInstance(ServiceProvider, t);
+                       }
+
+                       return (IMigration)Activator.CreateInstance(t);
+                   }));
     }
 
     static async Task Execute(IEnumerable<IMigration> migrations)

--- a/MongoDB.Entities/DB/DB.Migrate.cs
+++ b/MongoDB.Entities/DB/DB.Migrate.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -58,10 +57,7 @@ public static partial class DB
 
             assemblies = AppDomain.CurrentDomain
                                   .GetAssemblies()
-                                  .Where(
-                                      a =>
-                                          (!a.IsDynamic && !excludes.Any(n => a.FullName.StartsWith(n))) ||
-                                          a.FullName.StartsWith("MongoDB.Entities.Tests"));
+                                  .Where(a => (!a.IsDynamic && !excludes.Any(n => a.FullName.StartsWith(n))) || a.FullName.StartsWith("MongoDB.Entities.Tests"));
         }
         else
             assemblies = [targetType.Assembly];
@@ -72,25 +68,24 @@ public static partial class DB
 
         return !types.Any()
                    ? throw new InvalidOperationException("Didn't find any classes that implement IMigrate interface.")
-                   : Execute(types.Select(t =>
-                   {
-                       if (ServiceProvider != null)
-                       {
-                           return (IMigration)ActivatorUtilities.CreateInstance(ServiceProvider, t);
-                       }
+                   : Execute(
+                       types.Select(
+                           t =>
+                           {
+                               if (ServiceProvider != null)
+                                   return (IMigration)ServiceProvider.GetService(t);
 
-                       return (IMigration)Activator.CreateInstance(t);
-                   }));
+                               return (IMigration)Activator.CreateInstance(t);
+                           }));
     }
 
     static async Task Execute(IEnumerable<IMigration> migrations)
     {
-        var lastMigNum = await
-                             Find<Migration, int>()
-                                 .Sort(m => m.Number, Order.Descending)
-                                 .Project(m => m.Number)
-                                 .ExecuteFirstAsync()
-                                 .ConfigureAwait(false);
+        var lastMigNum = await Find<Migration, int>()
+                               .Sort(m => m.Number, Order.Descending)
+                               .Project(m => m.Number)
+                               .ExecuteFirstAsync()
+                               .ConfigureAwait(false);
 
         var dic = new SortedDictionary<int, (string name, IMigration migration)>();
 

--- a/MongoDB.Entities/DB/DB.cs
+++ b/MongoDB.Entities/DB/DB.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
@@ -7,7 +6,6 @@ using MongoDB.Driver;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace MongoDB.Entities;

--- a/MongoDB.Entities/DB/DB.cs
+++ b/MongoDB.Entities/DB/DB.cs
@@ -222,21 +222,4 @@ public static partial class DB
     {
         ServiceProvider = serviceProvider;
     }
-
-    /// <summary>
-    /// Registers all migration types (classes implementing IMigration).
-    /// This should be called during application startup to register migrations to the DI container.
-    /// </summary>
-    /// <param name="services">The IServiceCollection for Dependency Injection.</param>
-    public static void RegisterMigrations(IServiceCollection services)
-    {
-        var migrationTypes = AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(a => a.GetTypes())
-            .Where(t => typeof(IMigration).IsAssignableFrom(t) && !t.IsAbstract);
-
-        foreach (var migrationType in migrationTypes)
-        {
-            services.AddScoped(migrationType, migrationType);
-        }
-    }
 }

--- a/MongoDB.Entities/DB/DB.cs
+++ b/MongoDB.Entities/DB/DB.cs
@@ -1,12 +1,12 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace MongoDB.Entities;
 
@@ -33,11 +33,7 @@ public static partial class DB
             _ => true);
     }
 
-    /// <summary>
-    /// Optional ASP.NET Core Dependency Injection provider.
-    /// </summary>
-    internal static IServiceProvider? ServiceProvider { get; set; }
-
+    internal static IServiceProvider? ServiceProvider { get; private set; }
     internal static event Action? DefaultDbChanged;
 
     static readonly ConcurrentDictionary<string, IMongoDatabase> _dbs = new();
@@ -215,9 +211,7 @@ public static partial class DB
     /// Initializes the ASP.NET Core Dependency Injection provider.
     /// Call this during application startup.
     /// </summary>
-    /// <param name="serviceProvider">The IServiceProvider instance</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider" /> instance</param>
     public static void SetServiceProvider(IServiceProvider serviceProvider)
-    {
-        ServiceProvider = serviceProvider;
-    }
+        => ServiceProvider = serviceProvider;
 }

--- a/MongoDB.Entities/MongoDB.Entities.csproj
+++ b/MongoDB.Entities/MongoDB.Entities.csproj
@@ -30,7 +30,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
         <PackageReference Include="MongoDB.Driver" Version="3.2.0"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     </ItemGroup>

--- a/MongoDB.Entities/MongoDB.Entities.csproj
+++ b/MongoDB.Entities/MongoDB.Entities.csproj
@@ -30,6 +30,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
         <PackageReference Include="MongoDB.Driver" Version="3.2.0"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     </ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,9 @@ variables:
 
 steps:
   - script: |
-      wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | sudo apt-key add -
-      echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+      apt-get install gnupg curl
+      curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
+      echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
       sudo apt-get update
       sudo apt-get install -y mongodb-org
       mkdir $(System.DefaultWorkingDirectory)/mongodb
@@ -23,7 +24,7 @@ steps:
       mongod --fork --replSet 'MyRep' --dbpath $(System.DefaultWorkingDirectory)/mongodb --logpath $(System.DefaultWorkingDirectory)/mongodb/log/mongod.log
       mongosh --eval "rs.initiate()"
     workingDirectory: "$(System.DefaultWorkingDirectory)"
-    displayName: "Install MongoDB"
+    displayName: "Install MongoDB 8.0"
 
   - task: UseDotNet@2
     displayName: "Use .Net SDK"


### PR DESCRIPTION
* added generic migration class registration
* added service provider registration
* added DI support for the migration classes

Usage:

```
var app = builder.Build();
await DB.InitAsync(mongoDbSettings.DatabaseName, mongoDbSettings.ConnectionString[10..^6]);
DB.SetServiceProvider(app.Services);
await DB.MigrateAsync();
```

Now we can inject anything inside the migration constructor:

```
public class _001_seed_initial_data : IMigration
{
    private readonly IMongoDatabase _database;

    public _001_seed_initial_data(IMongoDatabase database)
    {
        _database = database;
    }

    public async Task UpgradeAsync()
    {
    }
}
```

Feel free provide any suggestions