### PR TITLE
The int64 tests where throwing duplicate key errors on my MacOs.

### DIFF
--- a/Tests/Int64Tests/TestCounting.cs
+++ b/Tests/Int64Tests/TestCounting.cs
@@ -10,7 +10,7 @@ public class CountingInt64
 {
     DBContext db;
 
-    Task Init(string Int64)
+    Task Init(string InitialName)
     {
         db = new MyDBInt64();
 
@@ -18,12 +18,12 @@ public class CountingInt64
 
         for (var i = 1; i <= 25; i++)
         {
-            list.Add(new() { Name = Int64, Age = 111 });
+            list.Add(new() { Name = InitialName, Age = 111 });
         }
 
         for (var i = 1; i <= 10; i++)
         {
-            list.Add(new() { Name = Int64, Age = 222 });
+            list.Add(new() { Name = InitialName, Age = 222 });
         }
 
         return list.SaveAsync();
@@ -39,7 +39,7 @@ public class CountingInt64
 
         Assert.IsTrue(count > 0);
     }
-
+    
     [TestMethod]
     public async Task count_with_lambda()
     {

--- a/Tests/Int64Tests/TestSaving.cs
+++ b/Tests/Int64Tests/TestSaving.cs
@@ -135,7 +135,7 @@ public class SavingInt64
 
         var res = await DB.Find<BookInt64>()
                           .Match(b => ids.Contains(b.ID))
-                          .Sort(b => b.ID, Order.Ascending)
+                          .Sort(b => b.ID, Order.Descending)
                           .ExecuteAsync();
 
         Assert.AreEqual(0, res[0].Price);
@@ -158,7 +158,7 @@ public class SavingInt64
 
         var res = await DB.Find<BookInt64>()
                           .Match(b => ids.Contains(b.ID))
-                          .Sort(b => b.ID, Order.Ascending)
+                          .Sort(b => b.ID, Order.Descending)
                           .ExecuteAsync();
 
         Assert.AreEqual(0, res[0].Price);
@@ -223,7 +223,7 @@ public class SavingInt64
 
         var res = await DB.Find<BookInt64>()
                           .Match(b => ids.Contains(b.ID))
-                          .Sort(b => b.ID, Order.Ascending)
+                          .Sort(b => b.ID, Order.Descending)
                           .ExecuteAsync();
 
         Assert.AreEqual(100, res[0].Price);
@@ -246,7 +246,7 @@ public class SavingInt64
 
         var res = await DB.Find<BookInt64>()
                           .Match(b => ids.Contains(b.ID))
-                          .Sort(b => b.ID, Order.Ascending)
+                          .Sort(b => b.ID, Order.Descending)
                           .ExecuteAsync();
 
         Assert.AreEqual(100, res[0].Price);

--- a/Tests/Models/Author/AuthorInt64.cs
+++ b/Tests/Models/Author/AuthorInt64.cs
@@ -1,5 +1,6 @@
 ﻿using MongoDB.Bson.Serialization.Attributes;
 using System;
+using System.Threading;
 
 namespace MongoDB.Entities.Tests;
 
@@ -8,9 +9,11 @@ public class AuthorInt64 : Author
 {
     [BsonId]
     public long ID { get; set; }
+    
+    public static Int64 nextID = Int64.MaxValue;
 
     public override object GenerateNewID()
-        => Convert.ToInt64(DateTime.UtcNow.Ticks);
+        => Interlocked.Decrement(ref nextID);
 
     public override bool HasDefaultID()
         => ID == 0;

--- a/Tests/Models/Book/BookInt64.cs
+++ b/Tests/Models/Book/BookInt64.cs
@@ -1,17 +1,20 @@
 ﻿using MongoDB.Bson.Serialization.Attributes;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace MongoDB.Entities.Tests;
 
 [Collection("BookInt64")]
 public class BookInt64 : Book
 {
+    public static Int64 nextID = Int64.MaxValue;
+
     [BsonId]
     public long ID { get; set; }
 
     public override object GenerateNewID()
-        => Convert.ToInt64(DateTime.UtcNow.Ticks);
+        => Interlocked.Decrement(ref nextID);
 
     public override bool HasDefaultID()
         => ID == 0;

--- a/Tests/Models/Flower/FlowerInt64.cs
+++ b/Tests/Models/Flower/FlowerInt64.cs
@@ -1,17 +1,20 @@
 ﻿using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Entities.Tests.Models;
 using System;
+using System.Threading;
 
 namespace MongoDB.Entities.Tests;
 
 [Collection("FlowerInt64")]
 public class FlowerInt64 : Flower
 {
+    public static Int64 nextID = Int64.MaxValue;
+
     [BsonId]
     public long Id { get; set; }
 
     public override object GenerateNewID()
-        => Convert.ToInt64(DateTime.UtcNow.Ticks);
+        => Interlocked.Decrement(ref nextID);
 
     public override bool HasDefaultID()
         => Id == 0;

--- a/Tests/Models/Genre/GenreInt64.cs
+++ b/Tests/Models/Genre/GenreInt64.cs
@@ -1,16 +1,19 @@
 ﻿using MongoDB.Bson.Serialization.Attributes;
 using System;
+using System.Threading;
 
 namespace MongoDB.Entities.Tests;
 
 [Collection("GenreInt64")]
 public class GenreInt64 : Genre
 {
+    public static Int64 nextID = Int64.MaxValue;
+
     [BsonId]
     public Int64 ID { get; set; }
 
     public override object GenerateNewID()
-        => Convert.ToInt64(DateTime.UtcNow.Ticks);
+        => Interlocked.Decrement(ref nextID);
 
     public override bool HasDefaultID()
         => ID == 0;

--- a/Tests/Models/Place/PlaceInt64.cs
+++ b/Tests/Models/Place/PlaceInt64.cs
@@ -1,16 +1,19 @@
 ﻿using MongoDB.Bson.Serialization.Attributes;
 using System;
+using System.Threading;
 
 namespace MongoDB.Entities.Tests;
 
 [Collection("PlaceInt64")]
 public class PlaceInt64 : Place
 {
+    public static Int64 nextID = Int64.MaxValue;
+
     [BsonId]
     public Int64 Id { get; set; }
 
     public override object GenerateNewID()
-          => Convert.ToInt64(DateTime.UtcNow.Ticks);
+        => Interlocked.Decrement(ref nextID);
 
     public override bool HasDefaultID()
           => Id == 0;


### PR DESCRIPTION
Changed generateId to use INT64.MaxValue and Interlocked.Decrement to generate unique IDs