### PR TITLE
Add support for providing a custom activator for migration classes

### DIFF
--- a/MongoDB.Entities/DB/DB.Migrate.cs
+++ b/MongoDB.Entities/DB/DB.Migrate.cs
@@ -72,6 +72,9 @@ public partial class DB
                        types.Select(
                            t =>
                            {
+                               if (MigrationActivator != null)
+                                   return MigrationActivator(t);
+                               
                                if (ServiceProvider != null)
                                    return (IMigration)ServiceProvider.GetService(t);
 

--- a/MongoDB.Entities/DB/DB.cs
+++ b/MongoDB.Entities/DB/DB.cs
@@ -36,7 +36,6 @@ public partial class DB
     internal IServiceProvider? ServiceProvider { get; private set; }
     internal Func<Type, IMigration>? MigrationActivator { get; private set; }
 
-
     static readonly ConcurrentDictionary<MongoClientSettings, MongoClient> _clients = new();
     static readonly ConcurrentDictionary<MongoClient, ConcurrentDictionary<string, DB>> _clientInstances = new();
     static MongoClientSettings _defaultClientSettings = null!; // to be set on first InitAsync call
@@ -259,7 +258,7 @@ public partial class DB
     /// <param name="serviceProvider">The <see cref="IServiceProvider" /> instance</param>
     public void SetServiceProvider(IServiceProvider serviceProvider)
         => ServiceProvider = serviceProvider;
-    
+
     /// <summary>
     /// Allows providing a custom activator for migration classes.
     /// Setting MigrationActivator supercedes calling the service provider if provided.

--- a/MongoDB.Entities/DB/DB.cs
+++ b/MongoDB.Entities/DB/DB.cs
@@ -34,6 +34,8 @@ public partial class DB
     }
 
     internal IServiceProvider? ServiceProvider { get; private set; }
+    internal Func<Type, IMigration>? MigrationActivator { get; private set; }
+
 
     static readonly ConcurrentDictionary<MongoClientSettings, MongoClient> _clients = new();
     static readonly ConcurrentDictionary<MongoClient, ConcurrentDictionary<string, DB>> _clientInstances = new();
@@ -257,6 +259,14 @@ public partial class DB
     /// <param name="serviceProvider">The <see cref="IServiceProvider" /> instance</param>
     public void SetServiceProvider(IServiceProvider serviceProvider)
         => ServiceProvider = serviceProvider;
+    
+    /// <summary>
+    /// Allows providing a custom activator for migration classes.
+    /// Setting MigrationActivator supercedes calling the service provider if provided.
+    /// </summary>
+    /// <param name="activator">A function that creates an IMigration instance from a Type</param>
+    public void SetMigrationActivator(Func<Type, IMigration> activator)
+        => MigrationActivator = activator;
 
     // ReSharper disable once VirtualMemberNeverOverridden.Global
     /// <summary>

--- a/MongoDB.Entities/MongoDB.Entities.csproj
+++ b/MongoDB.Entities/MongoDB.Entities.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
 
-        <Version>25.0.1-beta.1</Version>
+        <Version>25.0.1-beta.2</Version>
 
         <TargetFramework>netstandard2.1</TargetFramework>
         <RootNamespace>MongoDB.Entities</RootNamespace>

--- a/Tests/Init.cs
+++ b/Tests/Init.cs
@@ -44,6 +44,15 @@ public static class InitTest
             return await DB.InitAsync(databaseName, ClientSettings1);
         }
 
-        return await DB.InitAsync(databaseName);
+        return await DB.InitAsync(
+                   databaseName,
+                   new()
+                   {
+                       Server = new("localhost", 27017),
+                       Credential = MongoCredential.CreateCredential("admin", "admin", "password"),
+                       DirectConnection = true
+                   });
+
+        ;
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,7 @@
-[//]: # (### NEW)
+### NEW
 
-[//]: # (### IMPROVEMENTS)
+- Add `SetMigrationActivator(Func<Type, IMigration>)` method to support custom activation of migration classes.
 
-# ⚠️ Major Version With Breaking Changes ⚠️
+### IMPROVEMENTS
 
-Version 25 is a major version jump with many breaking changes. It is not recommended to upgrade to v25 unless you have the time to go through the [latest documentation](https://mongodb-entities.com/) and spend some effort to change your existing project code. It's not that complicated to upgrade but will involve a lot of manual work if your codebase is quite large. AI could possibly help with that.
-
-v25 modernizes the API and brings proper multi-database support. The old way of doing things via `DB` static calls is gone. All operations must now be performed via a `DB` instance. The extension methods targeting entities such as `myEntity.SaveAsync()` are no longer available. The features that were tied to `DBContext` has also been merged in to the `DB` class.
-
-A huge thanks to [David Berry](https://github.com/dberry-rcs) for doing most of the work on this release ❤️❤️❤️
+### FIXES


### PR DESCRIPTION
This approach allows passing in a function that calls ActivatorUtilities and means you don't need to register all the migration classes with DI if all you want is to pass in a registered database instance.